### PR TITLE
入部フォームへのリンクとメッセージを追加

### DIFF
--- a/src/components/sections/ContactForm/ContactForm.module.css
+++ b/src/components/sections/ContactForm/ContactForm.module.css
@@ -1,0 +1,49 @@
+.contact_wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.contact_wrapper div {
+  font-size: 1.3rem;
+  text-align: center;
+}
+
+.contact_button {
+  width: fit-content;
+  padding: 10px;
+  background-color: #0C64FD;
+  border: none;
+  border-radius: 100px;
+  color: white;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 1.4rem;
+  padding: 7px 25px;
+  margin-top: 10px;
+  transition: all 0.3s;
+}
+
+.contact_button:hover {
+  background-color: #084fcb;
+}
+
+/*レスポンシブ対応*/
+@media (max-width: 768px) {
+  .contact_wrapper div {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .contact_wrapper div {
+    width: 250px;
+  }
+
+  .contact_button {
+    font-size: 1.2rem;
+  }
+}

--- a/src/components/sections/ContactForm/ContactForm.tsx
+++ b/src/components/sections/ContactForm/ContactForm.tsx
@@ -1,7 +1,17 @@
+import styles from "./ContactForm.module.css";
+
 export const ContactForm = () => {
-    return (
-        <section id="contact" className="w-full">
-            {/* ContactForm implementation */}
-        </section>
-    )
-}
+  return (
+    <section id="contact" className={styles.contact_wrapper}>
+      <div>一緒に山口県のVR・メタバースを盛り上げていきませんか？</div>
+      <div>ご参加お待ちしてます！</div>
+      <a
+        href="https://docs.google.com/forms/d/e/1FAIpQLSd0OpMA5abBBNZe23VP0VNttOLtKtH9xeZi8fVd11lrkYBS6A/viewform"
+        target="_blank"
+        className={styles.contact_button}
+      >
+        入部フォーム
+      </a>
+    </section>
+  );
+};


### PR DESCRIPTION
## 概要
入部フォームに遷移するボタンとメッセージを表示
ページトップにスクロールするボタンは、ヘッダーと機能が被っているので実装していません

## 変更点
- ContactFormにボタンとテキストを追加
- ContactForm.module.cssを追加して、スタイルを定義
- 
![スクリーンショット 2025-03-10 183247](https://github.com/user-attachments/assets/ba7831cf-c7cc-48d1-9b08-50db74e59238)

## 影響範囲
ContactForm以外への影響は無し

## 関連Issue
close #11 
