### PR TITLE
自己紹介スライドを変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/components/sections/About/About.css
+++ b/src/components/sections/About/About.css
@@ -52,13 +52,13 @@
   margin-top: 1rem;
 }
 
-.speakerdeck-iframe-container {
+.googleslides-iframe-container {
   width: 100%;
   display: flex;
   justify-content: center;
 }
 
-.speakerdeck-iframe {
+.googleslides-iframe {
   border: none;
   background: padding-box padding-box rgba(0, 0, 0, 0.1);
   margin: 15px 0;

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -36,14 +36,13 @@ export const About = () => {
           </a>
         </div>
       </div>
-      <div className="speakerdeck-iframe-container">
+      <div className="googleslides-iframe-container">
         <iframe
-          className="speakerdeck-iframe"
+          className="googleslides-iframe"
+          title="自己紹介スライド"
+          src="https://docs.google.com/presentation/d/e/2PACX-1vQYs9R-n7ryGBCydjHpLiSg5ERNMB2NlwOdKA5C6KAtg-KXLspwQTZIFrfiobqSpBY_Ip8n8fm59hnH/pubembed?start=true&loop=true&delayms=5000"
           frameBorder={0}
-          src="https://speakerdeck.com/player/3a8b9736fe994ca0b4eec13627b3dd94"
-          title="アップロードテスト"
           allowFullScreen
-          data-ratio="1.7777777777777777"
         ></iframe>
       </div>
     </section>


### PR DESCRIPTION
## 概要
自己紹介スライドを変更
![スクリーンショット 2025-04-19 214249](https://github.com/user-attachments/assets/388f4969-aa1c-4322-a346-72a905f3e7d1)

![スクリーンショット 2025-04-19 214641](https://github.com/user-attachments/assets/ffe444db-a5a7-45d3-a561-158e1085c776)

## 変更点
- AboutセクションのiframeをGoogleスライドの埋め込みに変更した
- タグのクラス名を変更

## 影響範囲
Aboutセクション

## 関連Issue
close #49 
